### PR TITLE
Add Same Question UI and Backend Functionality

### DIFF
--- a/nodebb-theme-harmony/templates/partials/post_bar.tpl
+++ b/nodebb-theme-harmony/templates/partials/post_bar.tpl
@@ -7,6 +7,11 @@
 					<i class="fa fa-fw fa-inbox text-primary"></i>
 					<span class="d-none d-md-inline fw-semibold">[[topic:mark-unread]]</span>
 				</button>
+				<button id="sameQuestion" class="btn-ghost-sm ff-secondary d-flex gap-2 align-items-center">
+					<i class="fa fa-hand-paper text-primary"></i>
+					<span class="d-none d-md-inline fw-semibold">Same Question</span>
+					<span id="same-question-count" class="badge bg-primary text-light ms-2 px-2 py-1 rounded-circle">0</span>
+				</button>
 				{{{ end }}}
 
 				<!-- IMPORT partials/topic/resolved.tpl -->

--- a/nodebb-theme-harmony/templates/partials/post_bar.tpl
+++ b/nodebb-theme-harmony/templates/partials/post_bar.tpl
@@ -10,7 +10,7 @@
 				<button id="sameQuestion" class="btn-ghost-sm ff-secondary d-flex gap-2 align-items-center">
 					<i class="fa fa-hand-paper text-primary"></i>
 					<span class="d-none d-md-inline fw-semibold">Same Question</span>
-					<span id="same-question-count" class="badge bg-primary text-light ms-2 px-2 py-1 rounded-circle">0</span>
+					<span id="sameQuestionCount" class="badge bg-primary text-light ms-2 px-2 py-1 rounded-circle">0</span>
 				</button>
 				{{{ end }}}
 

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -24,6 +24,12 @@ define('forum/topic/threadTools', [
 			}
 		});
 
+		socket.emit('topics.sameQuestionCount', { tid }, function (err, result) {
+            if (!err && result.success) {
+                document.getElementById('sameQuestionCount').textContent = result.sameQCount;
+            }
+        });
+
 		renderMenu(topicContainer);
 
 		$('.topic-main-buttons [title]').tooltip({
@@ -158,6 +164,12 @@ define('forum/topic/threadTools', [
 			const currState = $(this).attr('data-status');
 			socket.emit('topics.setResolved', { tid: ajaxify.data.tid, status: currState }, function () {
 				ThreadTools.setResolveState(currState);
+			});
+		});
+
+		topicContainer.on('click', '#sameQuestion', function () {
+			socket.emit('topics.increaseSameQCount', { tid }, function (err, result) {
+				document.getElementById('sameQuestionCount').textContent = result.currCount;
 			});
 		});
 

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -24,15 +24,9 @@ define('forum/topic/threadTools', [
 			}
 		});
 
-		const button = document.getElementById('sameQuestion');
-
 		socket.emit('topics.sameQuestionCount', { tid }, function (err, result) {
 			if (!err && result.success) {
 				document.getElementById('sameQuestionCount').textContent = result.sameQCount;
-				if (result.hasClicked) {
-					button.disabled = true;
-					button.classList.add('disabled');
-				}
 			}
 		});
 
@@ -177,8 +171,6 @@ define('forum/topic/threadTools', [
 			socket.emit('topics.increaseSameQCount', { tid }, function (err, result) {
 				if (!err && result.success) {
 					document.getElementById('sameQuestionCount').textContent = result.currCount;
-					button.disabled = true;
-					button.classList.add('disabled');
 				}
 			});
 		});

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -27,6 +27,10 @@ define('forum/topic/threadTools', [
 		socket.emit('topics.sameQuestionCount', { tid }, function (err, result) {
             if (!err && result.success) {
                 document.getElementById('sameQuestionCount').textContent = result.sameQCount;
+				if (result.hasClicked) {
+                    button.disabled = true;
+                    button.classList.add('disabled');
+				}
             }
         });
 
@@ -169,7 +173,11 @@ define('forum/topic/threadTools', [
 
 		topicContainer.on('click', '#sameQuestion', function () {
 			socket.emit('topics.increaseSameQCount', { tid }, function (err, result) {
-				document.getElementById('sameQuestionCount').textContent = result.currCount;
+				if (!err && result.success) {
+					document.getElementById('sameQuestionCount').textContent = result.currCount;
+					button.disabled = true;
+					button.classList.add('disabled');
+				}
 			});
 		});
 

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -24,15 +24,17 @@ define('forum/topic/threadTools', [
 			}
 		});
 
+		const button = document.getElementById('sameQuestion');
+
 		socket.emit('topics.sameQuestionCount', { tid }, function (err, result) {
-            if (!err && result.success) {
-                document.getElementById('sameQuestionCount').textContent = result.sameQCount;
+			if (!err && result.success) {
+				document.getElementById('sameQuestionCount').textContent = result.sameQCount;
 				if (result.hasClicked) {
-                    button.disabled = true;
-                    button.classList.add('disabled');
+					button.disabled = true;
+					button.classList.add('disabled');
 				}
-            }
-        });
+			}
+		});
 
 		renderMenu(topicContainer);
 

--- a/src/socket.io/topics.js
+++ b/src/socket.io/topics.js
@@ -34,33 +34,33 @@ SocketTopics.getResolved = async function (socket, data) {
 
 SocketTopics.sameQuestionCount = async function (socket, data) {
 	const sameQCount = await db.getObjectField(`topic:${data.tid}`, 'sameQuestionCount') || 0;
-	let clickedUsers = await db.getObjectField(`topic:${data.tid}`, 'sameQuestionUsers') || "[]";
-    clickedUsers = JSON.parse(clickedUsers);
-    const hasClicked = clickedUsers.includes(socket.uid);
+	let clickedUsers = await db.getObjectField(`topic:${data.tid}`, 'sameQuestionUsers') || '[]';
+	clickedUsers = JSON.parse(clickedUsers);
+	const hasClicked = clickedUsers.includes(socket.uid);
 
-    return { success: true, sameQCount, hasClicked };
-}
+	return { success: true, sameQCount, hasClicked };
+};
 
 SocketTopics.increaseSameQCount = async function (socket, data) {
 	const canRead = await privileges.topics.can('topics:read', data.tid, socket.uid);
 	if (!canRead) {
 		throw new Error('[[no-privileges]]');
 	}
-	let clickedUsers = await db.getObjectField(`topic:${data.tid}`, 'sameQuestionUsers') || "[]";
-    clickedUsers = JSON.parse(clickedUsers);
+	let clickedUsers = await db.getObjectField(`topic:${data.tid}`, 'sameQuestionUsers') || '[]';
+	clickedUsers = JSON.parse(clickedUsers);
 
-    if (clickedUsers.includes(socket.uid)) {
-        return { success: false, message: 'Already clicked' };
-    }
+	if (clickedUsers.includes(socket.uid)) {
+		return { success: false, message: 'Already clicked' };
+	}
 
 	clickedUsers.push(socket.uid);
-    await db.setObjectField(`topic:${data.tid}`, 'sameQuestionUsers', JSON.stringify(clickedUsers));
-	
+	await db.setObjectField(`topic:${data.tid}`, 'sameQuestionUsers', JSON.stringify(clickedUsers));
+
 	let currCount = await db.getObjectField(`topic:${data.tid}`, 'sameQuestionCount') || 0;
-    currCount = parseInt(currCount, 10) + 1;
+	currCount = parseInt(currCount, 10) + 1;
 	await db.setObjectField(`topic:${data.tid}`, 'sameQuestionCount', currCount);
 	return { success: true, currCount };
-}
+};
 
 SocketTopics.postcount = async function (socket, tid) {
 	const canRead = await privileges.topics.can('topics:read', tid, socket.uid);

--- a/src/socket.io/topics.js
+++ b/src/socket.io/topics.js
@@ -32,6 +32,21 @@ SocketTopics.getResolved = async function (socket, data) {
 	return { success: true, resolved: isResolved };
 };
 
+SocketTopics.sameQuestionCount = async function (socket, data) {
+	const sameQCount = await db.getObjectField(`topic:${data.tid}`, 'sameQuestionCount') || 0;
+	return { success: true, sameQCount };
+}
+
+SocketTopics.increaseSameQCount = async function (socket, data) {
+	const canRead = await privileges.topics.can('topics:read', data.tid, socket.uid);
+	if (!canRead) {
+		throw new Error('[[no-privileges]]');
+	}
+	let currCount = await db.getObjectField(`topic:${data.tid}`, 'sameQuestionCount') || 0;
+    currCount = parseInt(currCount, 10) + 1;
+	await db.setObjectField(`topic:${data.tid}`, 'sameQuestionCount', currCount);
+	return { success: true, currCount };
+}
 
 SocketTopics.postcount = async function (socket, tid) {
 	const canRead = await privileges.topics.can('topics:read', tid, socket.uid);

--- a/src/socket.io/topics.js
+++ b/src/socket.io/topics.js
@@ -7,7 +7,6 @@ const posts = require('../posts');
 const topics = require('../topics');
 const user = require('../user');
 const meta = require('../meta');
-const privileges = require('../privileges');
 const cache = require('../cache');
 const events = require('../events');
 
@@ -42,10 +41,6 @@ SocketTopics.sameQuestionCount = async function (socket, data) {
 };
 
 SocketTopics.increaseSameQCount = async function (socket, data) {
-	const canRead = await privileges.topics.can('topics:read', data.tid, socket.uid);
-	if (!canRead) {
-		throw new Error('[[no-privileges]]');
-	}
 	let clickedUsers = await db.getObjectField(`topic:${data.tid}`, 'sameQuestionUsers') || '[]';
 	clickedUsers = JSON.parse(clickedUsers);
 
@@ -63,10 +58,6 @@ SocketTopics.increaseSameQCount = async function (socket, data) {
 };
 
 SocketTopics.postcount = async function (socket, tid) {
-	const canRead = await privileges.topics.can('topics:read', tid, socket.uid);
-	if (!canRead) {
-		throw new Error('[[no-privileges]]');
-	}
 	return await topics.getTopicField(tid, 'postcount');
 };
 

--- a/test/topics.js
+++ b/test/topics.js
@@ -903,6 +903,10 @@ describe('Topic\'s', () => {
 		});
 	});
 
+	describe('resolved status', () => {
+
+	});
+
 
 	describe('.ignore', () => {
 		let newTid;

--- a/test/topics.js
+++ b/test/topics.js
@@ -903,10 +903,85 @@ describe('Topic\'s', () => {
 		});
 	});
 
-	describe('resolved status', () => {
+	describe('resolved and unresolved topics', () => {
+		let newTid;
+		let uid;
+		let newTopic;
+		before(async () => {
+			uid = topic.userId;
+			const result = await topics.post({ uid: topic.userId, title: 'Topic to be resolved', content: 'Just resolve me, please!', cid: topic.categoryId });
+			newTopic = result.topicData;
+			newTid = newTopic.tid;
+			await socketTopics.setResolved({ uid }, { tid: newTid, status: 'Unresolved' });
+		});
 
+		it('should set resolved state correctly', async () => {
+			const result = await socketTopics.setResolved({ uid }, { tid: newTid, status: 'Resolved' });
+			assert.strictEqual(result.resolved, 1);
+			assert.strictEqual(result.success, true);
+		});
+
+		it('should retrieve resolved state correctly', async () => {
+			const result = await socketTopics.getResolved({ uid }, { tid: newTid });
+			assert.strictEqual(result.resolved, true);
+			assert.strictEqual(result.success, true);
+		});
+
+		it('should set unresolved state correctly', async () => {
+			const result = await socketTopics.setResolved({ uid }, { tid: newTid, status: 'Unresolved' });
+			assert.strictEqual(result.resolved, 0);
+			assert.strictEqual(result.success, true);
+		});
+
+		it('should retrieve unresolved state correctly', async () => {
+			const result = await socketTopics.getResolved({ uid }, { tid: newTid });
+			assert.strictEqual(result.resolved, false);
+			assert.strictEqual(result.success, true);
+		});
 	});
 
+	describe('same question topics', () => {
+		let newTid;
+		let uid;
+		let newTopic;
+		let otherUserUid;
+		before(async () => {
+			uid = topic.userId;
+			const result = await topics.post({ uid: topic.userId, title: 'Topic with same question', content: 'Just increase my count, please!', cid: topic.categoryId });
+			newTopic = result.topicData;
+			newTid = newTopic.tid;
+			otherUserUid = await User.create({ username: 'regularJoe' });
+		});
+
+		it('should start with zero count', async () => {
+			const result = await socketTopics.sameQuestionCount({ uid }, { tid: newTid });
+			assert.strictEqual(result.sameQCount, 0);
+			assert.strictEqual(result.hasClicked, false);
+			assert.strictEqual(result.success, true);
+		});
+
+		it('should increase count by 1 when clicked, stopping same user from clicking many times', async () => {
+			const result = await socketTopics.increaseSameQCount({ uid }, { tid: newTid });
+			assert.strictEqual(result.currCount, 1);
+			assert.strictEqual(result.success, true);
+			const result2 = await socketTopics.increaseSameQCount({ uid }, { tid: newTid });
+			assert.strictEqual(result2.success, false);
+			assert.strictEqual(result2.message, 'Already clicked');
+		});
+
+		it('should have correct updated count', async () => {
+			const result = await socketTopics.sameQuestionCount({ uid }, { tid: newTid });
+			assert.strictEqual(result.sameQCount, 1);
+			assert.strictEqual(result.hasClicked, true);
+			assert.strictEqual(result.success, true);
+		});
+
+		it('should allow other users to click and increase count', async () => {
+			const result = await socketTopics.increaseSameQCount({ uid: otherUserUid }, { tid: newTid });
+			assert.strictEqual(result.currCount, 2);
+			assert.strictEqual(result.success, true);
+		});
+	});
 
 	describe('.ignore', () => {
 		let newTid;

--- a/test/topics.js
+++ b/test/topics.js
@@ -971,7 +971,7 @@ describe('Topic\'s', () => {
 
 		it('should have correct updated count', async () => {
 			const result = await socketTopics.sameQuestionCount({ uid }, { tid: newTid });
-			assert.strictEqual(result.sameQCount, 1);
+			assert.strictEqual(Number(result.sameQCount), 1);
 			assert.strictEqual(result.hasClicked, true);
 			assert.strictEqual(result.success, true);
 		});


### PR DESCRIPTION
Issues addressed:
-resolves #29, resolves #30, resolves #26, resolves #28

Changes in codebase:
-In nodebb-theme-harmony/templates/partials/post_bar.tpl, added button and counter UI next to where the resolved button UI is imported
-In src/socket.io/topics.js, implemented backend Socket functions to get the same question count and increase the same question count by 1, including logic to add the user to clickedUser list so they cannot increase the count multiple times
-In public/src/client/topic/threadTools.js, added frontend changes to update the button count when clicked and sync this increment with the database

Tests:
-In test/topics.js, created two new test suites, one for the resolve button and one for the same question button
-Tests for the resolve button include: setting and retrieving the Resolved and Unresolved states correctly, initial state is set to Unresolved
-Tests for the same question button include: initialized with count of 0, clicking the button increases count by one, multiple users can increase the count, and one user can not continually increase the count

Additional information:
-Use GenAI for help with code development