### PR TITLE
Send whether or not post should be anonymous to backend and store in DB

### DIFF
--- a/nodebb-plugin-composer-default/static/lib/composer.js
+++ b/nodebb-plugin-composer-default/static/lib/composer.js
@@ -717,7 +717,7 @@ define('composer', [
 
 		let composerData = {
 			uuid: post_uuid,
-			isAnonymous: postData.isAnonymous
+			isAnonymous: postData.isAnonymous, 
 		};
 		let method = 'post';
 		let route = '';

--- a/nodebb-plugin-composer-default/static/lib/composer.js
+++ b/nodebb-plugin-composer-default/static/lib/composer.js
@@ -717,7 +717,7 @@ define('composer', [
 
 		let composerData = {
 			uuid: post_uuid,
-			isAnonymous: postData.isAnonymous, 
+			isAnonymous: postData.isAnonymous,
 		};
 		let method = 'post';
 		let route = '';

--- a/nodebb-plugin-composer-default/static/lib/composer.js
+++ b/nodebb-plugin-composer-default/static/lib/composer.js
@@ -717,6 +717,7 @@ define('composer', [
 
 		let composerData = {
 			uuid: post_uuid,
+			isAnonymous: postData.isAnonymous
 		};
 		let method = 'post';
 		let route = '';
@@ -808,7 +809,6 @@ define('composer', [
 				} else {
 					removeComposerHistory();
 				}
-
 				hooks.fire('action:composer.' + action, { composerData: composerData, data: data });
 			})
 			.catch((err) => {

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -33,6 +33,7 @@ module.exports = function (Topics) {
 			lastposttime: 0,
 			postcount: 0,
 			viewcount: 0,
+			isAnonymous: data.isAnonymous
 		};
 
 		if (Array.isArray(data.tags) && data.tags.length) {

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -33,7 +33,7 @@ module.exports = function (Topics) {
 			lastposttime: 0,
 			postcount: 0,
 			viewcount: 0,
-			isAnonymous: data.isAnonymous
+			isAnonymous: data.isAnonymous,
 		};
 
 		if (Array.isArray(data.tags) && data.tags.length) {


### PR DESCRIPTION
Issues addressed:
- Resolves #5 

Changes in codebase:
- In nodebb-plugin-composer-default/static/lib/composer.js, the isAnonymous value is added to the object being sent to the backend for the post. 
- In src/topics/create.js, isAnonymous field is added to the object being stored in the database with the value being the one passed in from the frontend. 

Tests:
- Manually tested by creating a post as anonymous and creating a post with name and seeing that the correct value is received in the backend by logging the received value. 