### PR TITLE
Add Same Question UI and Backend Functionality

### DIFF
--- a/nodebb-theme-harmony/templates/partials/post_bar.tpl
+++ b/nodebb-theme-harmony/templates/partials/post_bar.tpl
@@ -7,6 +7,11 @@
 					<i class="fa fa-fw fa-inbox text-primary"></i>
 					<span class="d-none d-md-inline fw-semibold">[[topic:mark-unread]]</span>
 				</button>
+				<button id="sameQuestion" class="btn-ghost-sm ff-secondary d-flex gap-2 align-items-center">
+					<i class="fa fa-hand-paper text-primary"></i>
+					<span class="d-none d-md-inline fw-semibold">Same Question</span>
+					<span id="sameQuestionCount" class="badge bg-primary text-light ms-2 px-2 py-1 rounded-circle">0</span>
+				</button>
 				{{{ end }}}
 
 				<!-- IMPORT partials/topic/resolved.tpl -->

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -24,6 +24,12 @@ define('forum/topic/threadTools', [
 			}
 		});
 
+		socket.emit('topics.sameQuestionCount', { tid }, function (err, result) {
+			if (!err && result.success) {
+				document.getElementById('sameQuestionCount').textContent = result.sameQCount;
+			}
+		});
+
 		renderMenu(topicContainer);
 
 		$('.topic-main-buttons [title]').tooltip({
@@ -158,6 +164,14 @@ define('forum/topic/threadTools', [
 			const currState = $(this).attr('data-status');
 			socket.emit('topics.setResolved', { tid: ajaxify.data.tid, status: currState }, function () {
 				ThreadTools.setResolveState(currState);
+			});
+		});
+
+		topicContainer.on('click', '#sameQuestion', function () {
+			socket.emit('topics.increaseSameQCount', { tid }, function (err, result) {
+				if (!err && result.success) {
+					document.getElementById('sameQuestionCount').textContent = result.currCount;
+				}
 			});
 		});
 

--- a/src/socket.io/topics.js
+++ b/src/socket.io/topics.js
@@ -32,6 +32,30 @@ SocketTopics.getResolved = async function (socket, data) {
 	return { success: true, resolved: isResolved };
 };
 
+SocketTopics.sameQuestionCount = async function (socket, data) {
+	const sameQCount = await db.getObjectField(`topic:${data.tid}`, 'sameQuestionCount') || 0;
+	let clickedUsers = await db.getObjectField(`topic:${data.tid}`, 'sameQuestionUsers') || '[]';
+	clickedUsers = JSON.parse(clickedUsers);
+	const hasClicked = clickedUsers.includes(socket.uid);
+	return { success: true, sameQCount, hasClicked };
+}
+
+SocketTopics.increaseSameQCount = async function (socket, data) {
+	let clickedUsers = await db.getObjectField(`topic:${data.tid}`, 'sameQuestionUsers') || '[]';
+	clickedUsers = JSON.parse(clickedUsers);
+
+	if (clickedUsers.includes(socket.uid)) {
+		return { success: false, message: 'Already clicked' };
+	}
+
+	clickedUsers.push(socket.uid);
+	await db.setObjectField(`topic:${data.tid}`, 'sameQuestionUsers', JSON.stringify(clickedUsers));
+
+	let currCount = await db.getObjectField(`topic:${data.tid}`, 'sameQuestionCount') || 0;
+	currCount = parseInt(currCount, 10) + 1;
+	await db.setObjectField(`topic:${data.tid}`, 'sameQuestionCount', currCount);
+	return { success: true, currCount };
+};
 
 SocketTopics.postcount = async function (socket, tid) {
 	const canRead = await privileges.topics.can('topics:read', tid, socket.uid);

--- a/src/socket.io/topics.js
+++ b/src/socket.io/topics.js
@@ -38,7 +38,7 @@ SocketTopics.sameQuestionCount = async function (socket, data) {
 	clickedUsers = JSON.parse(clickedUsers);
 	const hasClicked = clickedUsers.includes(socket.uid);
 	return { success: true, sameQCount, hasClicked };
-}
+};
 
 SocketTopics.increaseSameQCount = async function (socket, data) {
 	let clickedUsers = await db.getObjectField(`topic:${data.tid}`, 'sameQuestionUsers') || '[]';


### PR DESCRIPTION
Issues addressed:
-resolves #29 , resolves #30 , resolves #26 , resolves #28 

Changes in codebase:
-In nodebb-theme-harmony/templates/partials/post_bar.tpl, added button and counter UI next to where the resolved button UI is imported
-In src/socket.io/topics.js, implemented backend Socket functions to get the same question count and increase the same question count by 1, including logic to add the user to clickedUser list so they cannot increase the count multiple times
-In public/src/client/topic/threadTools.js, added frontend changes to update the button count when clicked and sync this increment with the database

Tests:
-In test/topics.js, created two new test suites, one for the resolve button and one for the same question button
-Tests for the resolve button include: setting and retrieving the Resolved and Unresolved states correctly, initial state is set to Unresolved
-Tests for the same question button include: initialized with count of 0, clicking the button increases count by one, multiple users can increase the count, and one user can not continually increase the count

Additional information:
-Use GenAI for help with code development